### PR TITLE
Escape dollar

### DIFF
--- a/snippets/pascal.json
+++ b/snippets/pascal.json
@@ -318,9 +318,9 @@
   "region": {
   "prefix": "region",
   "body": [
-    "{$REGION '${1:MyRegion}'}",
+    "{\\$REGION '${1:MyRegion}'}",
     "\t$0",
-    "{$ENDREGION}"
+    "{\\$ENDREGION}"
   ],
   "description": "region"
   },


### PR DESCRIPTION
The following warning appeared in the console after installing your extension:

> The "region"-snippet very likely confuses snippet-variables and snippet-placeholders. See https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-syntax for more details.

It appears the dollar sign in one of the snippets wasn't escaped, this PR fixes that.