### PR TITLE
[Discussion] [Live Share] Restricting language services to local files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,11 @@ import { PascalDefinitionProvider } from './definitionProvider';
 import { PascalReferenceProvider } from './referenceProvider';
 import { TagsBuilder } from './tagsBuilder';
 
+const documentSelector = [
+    { language: 'pascal', scheme: 'file' },
+    { language: 'pascal', scheme: 'untitled' }
+];
+
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
@@ -32,9 +37,9 @@ export function activate(context: vscode.ExtensionContext) {
     // language providers
     TagsBuilder.checkGlobalAvailable(context).then((value) => {
         if (value) {
-            context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(['pascal'], new PascalDocumentSymbolProvider()));
-            context.subscriptions.push(vscode.languages.registerDefinitionProvider(['pascal'], new PascalDefinitionProvider()));
-            context.subscriptions.push(vscode.languages.registerReferenceProvider(['pascal'], new PascalReferenceProvider()));
+            context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(documentSelector, new PascalDocumentSymbolProvider()));
+            context.subscriptions.push(vscode.languages.registerDefinitionProvider(documentSelector, new PascalDefinitionProvider()));
+            context.subscriptions.push(vscode.languages.registerReferenceProvider(documentSelector, new PascalReferenceProvider()));
         }
     });
 
@@ -121,7 +126,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 
     // 
-    context.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider('pascal', {
+    context.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(documentSelector, {
         provideDocumentFormattingEdits: (document, options) => {
 
             return new Promise((resolve, reject) => {
@@ -165,7 +170,7 @@ export function activate(context: vscode.ExtensionContext) {
         }
     }));
 
-    context.subscriptions.push(vscode.languages.registerDocumentRangeFormattingEditProvider('pascal', {
+    context.subscriptions.push(vscode.languages.registerDocumentRangeFormattingEditProvider(documentSelector, {
         provideDocumentRangeFormattingEdits: (document, range, options) => {
 
             return new Promise((resolve, reject) => {


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services for Pascal, this PR simply updates the current `DocumentSelector` to be limited to `file` and `untitled` (unsaved) files. This way, when someone has the Pascal extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

Outside of the context of Live Share (i.e. doing local Pascal development), this PR is simply a more explicit version of the existing behavior, and would be fully backwards-compatible.

*Note: As an example, the TypeScript/JavaScript language services that come in-box with VS Code [already have this scheme restriction](https://github.com/Microsoft/vscode/blob/master/extensions/typescript-language-features/src/utils/fileSchemes.ts#L12), and so this PR replicates that behavior.*