### PR TITLE
tigthen up activation events

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,14 @@
         "onCommand:pascal.generateTags",
         "onCommand:pascal.updateTags",
         "onCommand:pascal.whatsNew",
-        "*"
+        "workspaceContains:**/*.pas",
+        "workspaceContains:**/*.p",
+        "workspaceContains:**/*.dfm",
+        "workspaceContains:**/*.dpr",
+        "workspaceContains:**/*.dpk",
+        "workspaceContains:**/*.lfm",
+        "workspaceContains:**/*.dpr",
+        "workspaceContains:**/*.lpr"
     ],
     "main": "./out/src/extension",
     "icon": "images/icon.png",


### PR DESCRIPTION
I could not find why the extension requested to be activated outside of the times when files that are of "language:pascal" are opened, much less why it would need to be activated everywhere all the time... but that may be a mistake on my part, in which case the activation events this PR suggests should be used instead of "*".