### PR TITLE
snippets: close opened parentheses in function and procedure

### DIFF
--- a/snippets/pascal.json
+++ b/snippets/pascal.json
@@ -183,7 +183,7 @@
   "function end": {
   "prefix": "function",
   "body": [
-    "function ${1:MyFunction}(${2:params}:${3:integer};",
+    "function ${1:MyFunction}(${2:params}):${3:integer};",
     "begin",
     "\t$0",
     "end;"
@@ -259,7 +259,7 @@
   "procedure": {
   "prefix": "procedure",
   "body": [
-    "procedure ${1:MyProcedure}(${2:params};",
+    "procedure ${1:MyProcedure}(${2:params});",
     "begin",
     "\t$0",
     "end;"


### PR DESCRIPTION
The `procedure` and `function` snippet were missing a closing `)` after the parameterlist.

This PR adds those.