### PR TITLE
Add xml syntax for .dproj, .groupproj and .cbproj

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,19 @@
                     ".lpr"
                 ],
                 "configuration": "./pascal.configuration.json"
+            },
+            {
+                "id": "xml",
+                "aliases": [
+                    "dproj",
+                    "groupproj",
+                    "cbproj"
+                ],
+                "extensions": [
+                    ".dproj",
+                    ".groupproj",
+                    ".cbproj"
+                ]
             }
         ],
         "grammars": [


### PR DESCRIPTION
No other plugin links these 3 extensions to the xml syntax and they are important extensions for Delphi developers who use your extension.